### PR TITLE
feat: database management endpoints

### DIFF
--- a/db_sage/app/core/config/db.py
+++ b/db_sage/app/core/config/db.py
@@ -154,6 +154,46 @@ class PostgresManager:
             raise
         return [row[0] for row in self.cur.fetchall()]
 
+    def get_all_tables_and_columns(self):
+        """
+        Retrieves all tables in the public schema and their corresponding columns.
+        
+        Returns:
+            A list of dictionaries, where each dictionary represents a table.
+            The dictionary has two keys: 'table_name' and 'columns'.
+            'columns' is a list of column names for that table.
+        """
+        query = """
+        SELECT 
+            table_name,
+            array_agg(column_name::text) AS columns
+        FROM 
+            information_schema.columns
+        WHERE 
+            table_schema = 'public'
+        GROUP BY 
+            table_name
+        ORDER BY 
+            table_name;
+        """
+        
+        try:
+            self.cur.execute(query)
+            results = self.cur.fetchall()
+            
+            tables_and_columns = [
+                {
+                    'table_name': table_name,
+                    'columns': columns
+                }
+                for table_name, columns in results
+            ]
+            
+            return tables_and_columns
+        except psycopg2.Error as e:
+            print(f"Error retrieving tables and columns: {e}")
+            raise
+
     def get_table_definitions_for_prompt(self):
         """Retrieves the definitions of all tables in the 'public' schema as a formatted string.
 

--- a/db_sage/app/v1/routes/__init__.py
+++ b/db_sage/app/v1/routes/__init__.py
@@ -3,6 +3,7 @@ from db_sage.app.v1.routes.google_auth import google_auth
 from db_sage.app.v1.routes.auth import auth
 from db_sage.app.v1.routes.user import user_router
 from db_sage.app.v1.routes.prompt import prompt_router
+from db_sage.app.v1.routes.database import database_connection_router
 
 api_version_one = APIRouter(prefix="/api/v1")
 
@@ -10,3 +11,4 @@ api_version_one.include_router(auth)
 api_version_one.include_router(google_auth)
 api_version_one.include_router(user_router)
 api_version_one.include_router(prompt_router)
+api_version_one.include_router(database_connection_router)

--- a/db_sage/app/v1/routes/database.py
+++ b/db_sage/app/v1/routes/database.py
@@ -1,0 +1,100 @@
+from fastapi import APIRouter, Depends, status, HTTPException
+from sqlalchemy.orm import Session
+from typing import Annotated
+
+from db_sage.app.db.database import get_db
+from db_sage.app.core.dependencies.user import get_current_active_user
+from db_sage.app.v1.models import User
+from db_sage.app.v1.schemas.database import DatabaseUrl
+from db_sage.app.core.config.db import DatabaseStateManager
+from db_sage.app.utils.success_response import success_response
+
+database_connection_router = APIRouter(prefix="/database", tags=["Database"])
+
+@database_connection_router.post("/connect", status_code=status.HTTP_200_OK, response_model=success_response)
+async def connect_database(
+    data: DatabaseUrl,
+    user: Annotated[User, Depends(get_current_active_user)]
+):
+    """
+    Establish a connection to a database using the provided URL.
+
+    This endpoint attempts to connect to a database using the URL provided in the request body.
+    If successful, it retrieves and returns information about all tables and their columns in the database.
+    Only authenticated and active users can access this endpoint.
+
+    Args:
+        data (DatabaseUrl): A Pydantic model containing the database URL.
+        user (User): The current authenticated user, injected by FastAPI.
+
+    Returns:
+        dict: A success response containing:
+            - status_code (int): HTTP status code (200 for success).
+            - message (str): A success message.
+            - data (list): List of dictionaries, each containing table name and its columns.
+
+    Raises:
+        HTTPException: 
+            - 500 status code if the database connection fails.
+            - Any authentication-related exceptions from the `get_current_active_user` dependency.
+
+    Note:
+        This function uses a DatabaseStateManager to manage the database connection state.
+        The actual database operations are performed using a separate database connection object.
+    """
+
+    db_url = data.db_url
+
+    db_state = DatabaseStateManager()
+    if db_state.set_connection(db_url):
+        db = db_state.get_connection()
+        tables_and_columns = db.get_all_tables_and_columns()
+        return success_response(
+            status_code=200,
+            message="Database connection established successfully.",
+            data=tables_and_columns
+        )
+    else:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database connection failed.")
+
+
+@database_connection_router.post("/close", status_code=status.HTTP_200_OK, response_model=success_response)
+async def close_database_connection(
+    user: Annotated[User, Depends(get_current_active_user)]
+):
+    """
+    Close the current database connection.
+
+    This endpoint attempts to close the current active database connection.
+    It can be used to manually release database resources when they are no longer needed.
+    Only authenticated and active users can access this endpoint.
+
+    Args:
+        user (User): The current authenticated user, injected by FastAPI.
+
+    Returns:
+        dict: A success response containing:
+            - status_code (int): HTTP status code (200 for success).
+            - message (str): A success message indicating the connection was closed.
+
+    Raises:
+        HTTPException: 
+            - 404 status code if no active database connection exists.
+            - Any authentication-related exceptions from the `get_current_active_user` dependency.
+
+    Note:
+        This function uses a DatabaseStateManager to manage the database connection state.
+        After closing the connection, any attempts to use the database will require
+        re-establishing a connection.
+    """
+
+    db_state = DatabaseStateManager()
+    if db_state.get_connection() is not None:
+        db_state.close_connection()
+        return success_response(
+            status_code=200,
+            message="Database connection closed successfully.",
+        )
+    else:
+        raise HTTPException(status_code=404, detail="No active database connection found.")
+

--- a/db_sage/app/v1/schemas/database.py
+++ b/db_sage/app/v1/schemas/database.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+class DatabaseUrl(BaseModel):
+    """Schema for database connection request"""
+
+    db_url: str

--- a/db_sage/app/v1/services/prompt.py
+++ b/db_sage/app/v1/services/prompt.py
@@ -7,9 +7,6 @@ from db_sage.app.core.config.instruments import PostgresAgentInstruments
 from db_sage.app.core.config import llm
 from db_sage.app.utils.types import TurboTool
 from db_sage.app.v1.responses.prompt import SqlQueryResultsResponse, SqlQueryResponseData
-from db_sage.app.utils.settings import settings
-
-DB_URL = settings.QUERY_DATABASE
 
 
 class PromptService(Service):
@@ -42,7 +39,7 @@ class PromptService(Service):
         Raises:
             HTTPException: If no similar tables are found or other issues arise, an HTTP 400 error is raised indicating the need for existing tables.
         """
-        with PostgresAgentInstruments(DB_URL, "prompt-endpoint") as (agent_instruments, db):
+        with PostgresAgentInstruments("prompt-endpoint") as (agent_instruments, db):
 
             # ---------------- BUILDING TABLE DEFINITIONS ----------------
 


### PR DESCRIPTION
I added the database management endpoints to the project at `/api/v1/database/*`.

## Description

This endpoint handle the various database management functionalities.
- `/api/v1/database/connect`, `POST`, starts a connection with a database.
- `/apiv1/database/close`, `POST`,  closes a database connection.

## Related Issue (Link to issue ticket)

The issue for this pull request can be found [here](https://github.com/Okunola11/DBSage/issues/4).

## Motivation and Context

This features provides full control over database management to the users. They can connect any database they want and close the connection at anytime. DBSage also saves no data from the database.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)    ​

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the readme accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
