### PR TITLE
chore: Set Default Success Field Value to True in Base Response

### DIFF
--- a/db_sage/app/core/base/responses.py
+++ b/db_sage/app/core/base/responses.py
@@ -9,7 +9,7 @@ class BaseResponseData(BaseModel):
 class BaseResponse(BaseModel):
     """Base schema for all responses"""
 
-    success: bool
+    success: bool = True    
     status_code: int = 200
     message: str
     data: Optional[Any] = {}


### PR DESCRIPTION
This pull request updates the base response model to set the default value of the 'success' field to True.

### Changes

*   Updated `success` field in base response model to default to `True`


### Rationale

Setting the default success value to True ensures that:

*   Successful queries have a clear indication of success.
*   Reduces potential errors due to unset values.

### Checklist

[x] Tested API responses with default success value.
[x] Verified no breaking changes.