### PR TITLE
refactor: Synchronized google login api route with the frontend

### DIFF
--- a/db_sage/app/v1/routes/google_auth.py
+++ b/db_sage/app/v1/routes/google_auth.py
@@ -5,12 +5,38 @@ from starlette.responses import RedirectResponse
 from authlib.integrations.base_client import OAuthError
 from authlib.oauth2.rfc6749 import OAuth2Token
 import secrets
+import requests
 
 from db_sage.app.db.database import get_db
 from db_sage.app.core.config.google_oauth_config import google_oauth
+from db_sage.app.v1.schemas.google_oauth import OAuthToken
+
 from db_sage.app.v1.services.google_oauth import GoogleOAuthService
 
 google_auth = APIRouter(prefix="/auth", tags=["Authentication"])
+
+@google_auth.post("/google")
+async def google_login(request_token: OAuthToken, db: Annotated[Session, Depends(get_db)]):
+    try:
+        id_token = request_token.id_token
+        google_profile_endpoint = f"https://www.googleapis.com/oauth2/v3/tokeninfo?id_token={id_token}"
+        google_response = requests.get(google_profile_endpoint)
+    
+        if google_response.status_code != 200:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Failed to fetch user info")
+
+        profile_data = google_response.json()
+
+        # Wrap profile_data in a new dictionary with 'userinfo' as the key
+        # This is needed by the google_auth_service create method called below.
+        response = {'userinfo': profile_data}
+
+        # create oauth data for the user 
+        google_oauth_service = GoogleOAuthService()
+        return google_oauth_service.create(response, db)
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Authentication failed")
+    
 
 @google_auth.get("/google")
 async def google_oauth2(request: Request) -> RedirectResponse:

--- a/db_sage/app/v1/schemas/google_oauth.py
+++ b/db_sage/app/v1/schemas/google_oauth.py
@@ -1,33 +1,4 @@
-from datetime import datetime
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel
 
-class UserData(BaseModel):
-    """
-    Schema response for validated google login
-    """
-    id: str
-    first_name: str
-    last_name: str 
-    email: EmailStr
-    created_at: datetime
-
-    class Config:
-        from_attributes = True
-
-class Tokens(BaseModel):
-    """
-    Schema for generated tokens response
-    """
-    access_token: str
-    refresh_token: str
-    token_type: str
-
-class StatusResponse(BaseModel):
-    """
-    Response schema for the end user 
-    """
-    message: str
-    status: str
-    status_code: int = 200
-    tokens: Tokens
-    user: UserData
+class OAuthToken(BaseModel):
+    id_token: str

--- a/db_sage/app/v1/services/google_oauth.py
+++ b/db_sage/app/v1/services/google_oauth.py
@@ -1,14 +1,15 @@
-from fastapi import Depends, HTTPException, status
-from datetime import datetime, timezone
+from fastapi import Depends, HTTPException, status, Response
+from datetime import datetime, timezone, timedelta
 from sqlalchemy.orm import Session
 from typing import Annotated, Union
 
 from db_sage.app.db.database import get_db
-from db_sage.app.v1.models.user import User
+from db_sage.app.v1.models.user import User, UserToken
 from db_sage.app.v1.models.oauth import OAuth
 from db_sage.app.core.base.services import Service
 from db_sage.app.utils.logger import logger
-from db_sage.app.v1.schemas.google_oauth import UserData, Tokens, StatusResponse
+from db_sage.app.v1.services.user import user_service
+from db_sage.app.v1.responses.user import UserResponseData, UserLoginResponse
 
 
 class GoogleOAuthService(Service):
@@ -42,7 +43,7 @@ class GoogleOAuthService(Service):
                     print("OAuth data already exists")
                     self.update(oauth_data, google_response, db)
                     # pass the existing user to the get_response method to generate a response object 
-                    user_response = self.get_response(existing_user)
+                    user_response = self.get_response(existing_user, db)
                     # return the response
                     return user_response
                 else:
@@ -54,7 +55,7 @@ class GoogleOAuthService(Service):
                             user_id=existing_user.id,
                             provider="google",
                             sub=user_info.get("sub"),
-                            access_token=google_response.get("access_token"),
+                            access_token=google_response.get("access_token", ""),
                             refresh_token=google_response.get("refresh_token", "")
                         )
                         # add and commit to get the inserted_id
@@ -65,7 +66,7 @@ class GoogleOAuthService(Service):
                         existing_user.update_at = datetime.now(timezone.utc)
                         db.commit()
                         # pass the user object to get_response method to generate a response object 
-                        user_response = self.get_response(existing_user)
+                        user_response = self.get_response(existing_user, db)
                         # return the response
                         return user_response
                     except Exception as exc:
@@ -79,7 +80,11 @@ class GoogleOAuthService(Service):
                     new_user = User(
                         first_name=user_info.get("given_name"),
                         last_name=user_info.get("family_name"),
-                        email=user_info.get("email")
+                        email=user_info.get("email"),
+                        is_active=True,
+                        is_verified=True,
+                        updated_at=datetime.now(timezone.utc),
+                        verified_at=datetime.now(timezone.utc)
                     )
                     # commit to get the user_id
                     db.add(new_user)
@@ -91,7 +96,7 @@ class GoogleOAuthService(Service):
                         user_id=new_user.id,
                         provider="google",
                         sub=user_info.get("sub"),
-                        access_token=google_response.get("access_token"),
+                        access_token=google_response.get("access_token", ""),
                         refresh_token=google_response.get("refresh_token", "")
                     )
                     # add and commit to get the inserted_id
@@ -112,7 +117,7 @@ class GoogleOAuthService(Service):
                 db.refresh(new_user)
 
                 # pass the user object to the get_response model to get a response
-                user_response = self.get_response(new_user)
+                user_response = self.get_response(new_user, db)
                 # return the user response
                 return user_response
 
@@ -141,7 +146,7 @@ class GoogleOAuthService(Service):
         """
         try:
             # update the access and refresh token 
-            oauth_data.access_token = google_response.get("access_token")
+            oauth_data.access_token = google_response.get("access_token", "")
             oauth_data.refresh_token = google_response.get("refresh_token", "")
             oauth_data.updated_at = datetime.now(timezone.utc)
             # commit and return the user object 
@@ -150,7 +155,7 @@ class GoogleOAuthService(Service):
             db.rollback()
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Exception occured in update method; {exc}")
 
-    def get_response(self, user: object) -> object:
+    def get_response(self, user: object, db: Annotated[Session, Depends(get_db)]) -> object:
         """Creates a response for the end user 
 
         Args:
@@ -161,24 +166,41 @@ class GoogleOAuthService(Service):
         """
 
         try:
-            # create a user data for response
-            user_response = UserData.model_validate(user, strict=True, from_attributes=True)
-            # create access token
-            ########################
-            # create refresh token
-            ###########################
-            tokens = Tokens(
-                access_token="some_random_stuff",
-                refresh_token="some random stuff",
-                token_type="bearer"
+            # check if the user has existing tokens that are yet to expire
+            existing_token = db.query(UserToken).filter(
+                UserToken.user_id == user.id, 
+                UserToken.expires_at > datetime.utcnow()
+                ).first()
+
+            if existing_token:
+                existing_token.expires_at = datetime.utcnow()
+                db.add(existing_token)
+                db.commit()
+
+            tokens = user_service._generate_tokens(user, db)
+
+            user_data = UserResponseData.model_validate(user)
+
+            pydantic_model = UserLoginResponse(
+                message="Login successful",
+                access_token=tokens['access_token'],
+                expires_in=tokens['expires_in'],
+                data=user_data
             )
-            # return the response data
-            return StatusResponse(
-                message="Authentication was successful",
-                status="successful",
-                status_code=200,
-                tokens=tokens,
-                user=user_response
+
+            # create a response object
+            response = Response(
+                content=pydantic_model.json(), status_code=status.HTTP_200_OK, media_type='application/json'
+                )
+
+            response.set_cookie(
+                key="refresh_token",
+                value=tokens['refresh_token'],
+                expires=timedelta(days=30),
+                httponly=True,
+                secure=True,
+                samesite="none"
             )
+            return response
         except Exception as exc:
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Exception occured in get_response method; {exc}")

--- a/tests/v1/auth/test_google_oauth.py
+++ b/tests/v1/auth/test_google_oauth.py
@@ -46,13 +46,13 @@ def test_google_login(client, test_session, mock_google_oauth2):
     response = client.get("/api/v1/auth/google")
 
     assert response.status_code == 200
-    assert response.json()['tokens']['token_type'] == 'bearer'
-    assert response.json()['user']['email'] == return_value['userinfo']['email']
-    assert response.json()['user']['first_name'] == return_value['userinfo']['given_name']
-    assert response.json()['user']['last_name'] == return_value['userinfo']['family_name']
+    assert response.json()['message'] == 'Login successful'
+    assert response.json()['data']['email'] == return_value['userinfo']['email']
+    assert response.json()['data']['first_name'] == return_value['userinfo']['given_name']
+    assert response.json()['data']['last_name'] == return_value['userinfo']['family_name']
 
     # test user is saved to db and the oauth data is saved
-    user_id = response.json()['user']['id']
+    user_id = response.json()['data']['id']
     user = test_session.query(User).filter_by(id=user_id).first()
 
     assert user.first_name == return_value['userinfo']['given_name']


### PR DESCRIPTION
I added a new POST endpoint at `/api/v1/auth/google`. This accepts the generated `id_token` by NextAuth from the frontend then makes an api request to google api to fetch the users data.

The endpoint:
- Returns standardized `auth` response.
- Includes access token, cookie, and refreshToken.
- Align with login endpoint responses.
- Improve consistency and reusability.

## Related Issue (Link to issue ticket)

The issue for this pull request can be found [here](https://github.com/Okunola11/DBSage/issues/16).

## Motivation and Context

This change makes `google login` work while synchronizing `NextAuth` with our `backend api`.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)    ​

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the readme accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
